### PR TITLE
Fix cron job runtime for Prisma compatibility

### DIFF
--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -3,7 +3,8 @@ import { prisma } from '@/lib/prisma';
 import { Resend } from 'resend';
 import { DateEvent, User } from '@prisma/client';
 
-export const runtime = 'edge';
+// Using Node.js runtime for Prisma compatibility
+// export const runtime = 'edge';
 
 type ReminderType = '1_DAY' | '3_DAYS' | '1_WEEK' | '2_WEEKS' | '1_MONTH';
 


### PR DESCRIPTION
- Disable edge runtime which doesn't support Prisma
- Use Node.js runtime for database operations
- Fixes PrismaClient browser environment error