### PR TITLE
Fix Next.js workspace root warning by setting outputFileTracingRoot

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,7 @@ const nextConfig = {
     ],
   },
   serverExternalPackages: ['@prisma/client'],
+  outputFileTracingRoot: __dirname,
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Added `outputFileTracingRoot: __dirname` to next.config.js to resolve: "Warning: Next.js inferred your workspace root, but it may not be correct. We detected multiple lockfiles and selected the directory of /Users/shaibenshalom/package-lock.json as the root directory."

This explicitly tells Next.js that the project root is the current directory, preventing it from incorrectly detecting the parent directory's package-lock.json as the workspace root.

Fixes:
- Eliminates workspace root detection warnings
- Ensures correct file tracing for production builds
- Improves build performance by proper root detection

🤖 Generated with [Claude Code](https://claude.ai/code)